### PR TITLE
Add v0.28.0 binaries

### DIFF
--- a/kava-10/v0.28.0-binaries.json
+++ b/kava-10/v0.28.0-binaries.json
@@ -1,6 +1,6 @@
 {
   "binaries": {
-    "linux/amd64": "https://github.com/Kava-Labs/kava/releases/download/v0.28.0/kava-v0.28.0-linux-amd64?checksum=sha256:",
-    "linux/arm64": "https://github.com/Kava-Labs/kava/releases/download/v0.28.0/kava-v0.28.0-linux-arm64?checksum=sha256:"
+    "linux/amd64": "https://github.com/Kava-Labs/kava/releases/download/v0.28.0/kava-v0.28.0-linux-amd64?checksum=sha256:c6b0c5fa9077a3c69d5f3877821954ee10b3305fe60ba5171268a728a76855af",
+    "linux/arm64": "https://github.com/Kava-Labs/kava/releases/download/v0.28.0/kava-v0.28.0-linux-arm64?checksum=sha256:83d95c1faf9c8043713cdaf79994eab81a932769deadec95a9736f102ebd28ff"
   }
 }

--- a/kava-10/v0.28.0-binaries.json
+++ b/kava-10/v0.28.0-binaries.json
@@ -1,0 +1,6 @@
+{
+  "binaries": {
+    "linux/amd64": "https://github.com/Kava-Labs/kava/releases/download/v0.28.0/kava-v0.28.0-linux-amd64?checksum=sha256:",
+    "linux/arm64": "https://github.com/Kava-Labs/kava/releases/download/v0.28.0/kava-v0.28.0-linux-arm64?checksum=sha256:"
+  }
+}


### PR DESCRIPTION
```bash
$ ./verify-checksum.sh ./kava-10/v0.28.0-binaries.json
Found 2 binaries:
linux/amd64 linux/arm64

Downloading linux/amd64 from https://github.com/Kava-Labs/kava/releases/download/v0.28.0/kava-v0.28.0-linux-amd64
Verifying checksum...
/var/folders/85/82f1dtv96x51mwjj7dpmvm6h0000gn/T/tmp.NSHjwJaA/linux-amd64: OK
PASS: linux/amd64 - c6b0c5fa9077a3c69d5f3877821954ee10b3305fe60ba5171268a728a76855af

Downloading linux/arm64 from https://github.com/Kava-Labs/kava/releases/download/v0.28.0/kava-v0.28.0-linux-arm64
Verifying checksum...
/var/folders/85/82f1dtv96x51mwjj7dpmvm6h0000gn/T/tmp.NSHjwJaA/linux-arm64: OK
PASS: linux/arm64 - 83d95c1faf9c8043713cdaf79994eab81a932769deadec95a9736f102ebd28ff
```